### PR TITLE
CustomDateTimeScalar for date-time Strings that aren't RFC 3339 Compliant

### DIFF
--- a/packages/handlers/openapi/package.json
+++ b/packages/handlers/openapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphql-mesh/openapi",
-  "version": "0.95.5-TeslaOpenAPIFixes-3",
+  "version": "0.95.5-OpenAPIFixes",
   "type": "module",
   "repository": {
     "type": "git",
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@graphql-mesh/string-interpolation": "0.5.1",
-    "@omnigraph/openapi": "0.95.5-TeslaOpenAPIFixes-2"
+    "@omnigraph/openapi": "0.95.5-OpenAPIFixes"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/handlers/openapi/package.json
+++ b/packages/handlers/openapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphql-mesh/openapi",
-  "version": "0.95.5-TeslaOpenapiFixes",
+  "version": "0.95.5-TeslaOpenAPIFixes",
   "type": "module",
   "repository": {
     "type": "git",
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@graphql-mesh/string-interpolation": "0.5.1",
-    "@omnigraph/openapi": "0.95.5-TeslaOpenapiFixes"
+    "@omnigraph/openapi": "0.95.5-TeslaOpenAPIFixes"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/handlers/openapi/package.json
+++ b/packages/handlers/openapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphql-mesh/openapi",
-  "version": "0.95.5",
+  "version": "0.95.5-TeslaOpenapiFixes",
   "type": "module",
   "repository": {
     "type": "git",
@@ -40,11 +40,12 @@
   },
   "dependencies": {
     "@graphql-mesh/string-interpolation": "0.5.1",
-    "@omnigraph/openapi": "0.95.5"
+    "@omnigraph/openapi": "0.95.5-TeslaOpenapiFixes"
   },
   "publishConfig": {
     "access": "public",
-    "directory": "dist"
+    "directory": "dist",
+    "registry": "https://artifactory.teslamotors.com/artifactory/api/npm/digital-products-node-prod/"
   },
   "sideEffects": false,
   "buildOptions": {

--- a/packages/handlers/openapi/package.json
+++ b/packages/handlers/openapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphql-mesh/openapi",
-  "version": "0.95.5-TeslaOpenAPIFixes-1",
+  "version": "0.95.5-TeslaOpenAPIFixes-2",
   "type": "module",
   "repository": {
     "type": "git",
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@graphql-mesh/string-interpolation": "0.5.1",
-    "@omnigraph/openapi": "0.95.5-TeslaOpenAPIFixes"
+    "@omnigraph/openapi": "0.95.5-TeslaOpenAPIFixes-1"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/handlers/openapi/package.json
+++ b/packages/handlers/openapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphql-mesh/openapi",
-  "version": "0.95.5-TeslaOpenAPIFixes",
+  "version": "0.95.5-TeslaOpenAPIFixes-1",
   "type": "module",
   "repository": {
     "type": "git",

--- a/packages/handlers/openapi/package.json
+++ b/packages/handlers/openapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphql-mesh/openapi",
-  "version": "0.95.5-TeslaOpenAPIFixes-2",
+  "version": "0.95.5-TeslaOpenAPIFixes-3",
   "type": "module",
   "repository": {
     "type": "git",
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@graphql-mesh/string-interpolation": "0.5.1",
-    "@omnigraph/openapi": "0.95.5-TeslaOpenAPIFixes-1"
+    "@omnigraph/openapi": "0.95.5-TeslaOpenAPIFixes-2"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/loaders/json-schema/package.json
+++ b/packages/loaders/json-schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omnigraph/json-schema",
-  "version": "0.95.5-TeslaOpenAPIFixes",
+  "version": "0.95.5-TeslaOpenAPIFixes-1",
   "type": "module",
   "repository": {
     "type": "git",
@@ -49,6 +49,7 @@
     "graphql-compose": "9.0.10",
     "graphql-scalars": "^1.22.2",
     "json-machete": "0.95.4",
+    "moment": "^2.29.4",
     "pascal-case": "3.1.2",
     "qs": "6.11.2",
     "to-json-schema": "0.2.5",

--- a/packages/loaders/json-schema/package.json
+++ b/packages/loaders/json-schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omnigraph/json-schema",
-  "version": "0.95.5-TeslaOpenAPIFixes-1",
+  "version": "0.95.5-OpenAPIFixes",
   "type": "module",
   "repository": {
     "type": "git",

--- a/packages/loaders/json-schema/package.json
+++ b/packages/loaders/json-schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omnigraph/json-schema",
-  "version": "0.95.5",
+  "version": "0.95.5-TeslaOpenAPIFixes",
   "type": "module",
   "repository": {
     "type": "git",

--- a/packages/loaders/json-schema/src/getComposerFromJSONSchema.ts
+++ b/packages/loaders/json-schema/src/getComposerFromJSONSchema.ts
@@ -32,7 +32,6 @@ import {
 import {
   GraphQLBigInt,
   GraphQLByte,
-  GraphQLDateTime,
   GraphQLEmailAddress,
   GraphQLIPv4,
   GraphQLIPv6,
@@ -70,7 +69,7 @@ import {
 import { getJSONSchemaStringFormatScalarMap } from './getJSONSchemaStringFormatScalarMap.js';
 import { getUnionTypeComposers } from './getUnionTypeComposers.js';
 import { getValidTypeName } from './getValidTypeName.js';
-import { GraphQLFile, GraphQLVoid } from './scalars.js';
+import { GraphQLCustomDateTime, GraphQLFile, GraphQLVoid } from './scalars.js';
 
 export interface TypeComposers {
   input?: AnyTypeComposer<any>;
@@ -362,7 +361,7 @@ export function getComposerFromJSONSchema(
             };
           }
           case 'date-time': {
-            const typeComposer = schemaComposer.getAnyTC(GraphQLDateTime);
+            const typeComposer = schemaComposer.getAnyTC(GraphQLCustomDateTime);
             return {
               input: typeComposer,
               output: typeComposer,

--- a/packages/loaders/json-schema/src/scalars.ts
+++ b/packages/loaders/json-schema/src/scalars.ts
@@ -65,9 +65,9 @@ export const GraphQLCustomDateTime = new GraphQLScalarType({
     if (typeof value === 'string' && !validateDateTime(value)) {
       // If the value doesn't match the RFC 3339, convert it to RFC 3339
       const formattedDate = moment(value).toISOString();
-      return GraphQLDateTime.serialize(formattedDate);
+      return GraphQLDateTime.serialize(formattedDate).toISOString();
     }
-    return GraphQLDateTime.serialize(value);
+    return GraphQLDateTime.serialize(value).toISOString();
   },
   parseValue: GraphQLDateTime.parseValue,
   parseLiteral: GraphQLDateTime.parseLiteral,

--- a/packages/loaders/json-schema/src/scalars.ts
+++ b/packages/loaders/json-schema/src/scalars.ts
@@ -1,4 +1,6 @@
 import { GraphQLScalarType } from 'graphql';
+import { GraphQLDateTime } from 'graphql-scalars';
+import moment from 'moment';
 
 export const GraphQLFile = new GraphQLScalarType({
   name: 'File',
@@ -27,4 +29,46 @@ export const ObjMapScalar = new GraphQLScalarType({
     }
     return null;
   },
+});
+
+export const GraphQLCustomDateTime = new GraphQLScalarType({
+  name: 'CustomDateTime',
+  description:
+    'Custom DateTime scalar that wraps GraphQLDateTimeConfig and converts non-RFC 3339 strings to RFC 3339.',
+  serialize: value => {
+    // helper to check if the date-time string is RFC 3339 compliant
+    const validateDateTime = (dateTimeString: string) => {
+      dateTimeString =
+        dateTimeString === null || dateTimeString === void 0
+          ? void 0
+          : dateTimeString.toUpperCase();
+      const RFC_3339_REGEX =
+        /^(\d{4}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9]|60))(\.\d{1,})?(([Z])|([+|-]([01][0-9]|2[0-3]):[0-5][0-9]))$/;
+      // Validate the structure of the date-string
+      if (!RFC_3339_REGEX.test(dateTimeString)) {
+        return false;
+      }
+      // Check if it is a correct date using the javascript Date parse() method.
+      const time = Date.parse(dateTimeString);
+      if (time !== time) {
+        // eslint-disable-line
+        return false;
+      }
+      // Split the date-time-string up into the string-date and time-string part.
+      // and check whether these parts are RFC 3339 compliant.
+      const index = dateTimeString.indexOf('T');
+      const dateString = dateTimeString.substr(0, index);
+      const timeString = dateTimeString.substr(index + 1);
+      return (0, exports.validateDate)(dateString) && (0, exports.validateTime)(timeString);
+    };
+
+    if (typeof value === 'string' && !validateDateTime(value)) {
+      // If the value doesn't match the RFC 3339, convert it to RFC 3339
+      const formattedDate = moment(value).toISOString();
+      return GraphQLDateTime.serialize(formattedDate);
+    }
+    return GraphQLDateTime.serialize(value);
+  },
+  parseValue: GraphQLDateTime.parseValue,
+  parseLiteral: GraphQLDateTime.parseLiteral,
 });

--- a/packages/loaders/json-schema/src/scalars.ts
+++ b/packages/loaders/json-schema/src/scalars.ts
@@ -31,37 +31,37 @@ export const ObjMapScalar = new GraphQLScalarType({
   },
 });
 
+// helper to check if the date-time string is RFC 3339 compliant
+const validateDateTime = (dateTimeString: string) => {
+  dateTimeString =
+    dateTimeString === null || dateTimeString === void 0 ? void 0 : dateTimeString.toUpperCase();
+  // It is a combination of the date and time regex that is also used in the GraphQL Scalars package.
+  // https://the-guild.dev/graphql/scalars/docs/scalars/date-time
+  const RFC_3339_REGEX =
+    /^(\d{4}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9]|60))(\.\d{1,})?(([Z])|([+|-]([01][0-9]|2[0-3]):[0-5][0-9]))$/;
+  // Validate the structure of the date-string
+  if (!RFC_3339_REGEX.test(dateTimeString)) {
+    return false;
+  }
+  // Check if it is a correct date using the javascript Date parse() method.
+  const time = Date.parse(dateTimeString);
+  if (time !== time) {
+    // eslint-disable-line
+    return false;
+  }
+  // Split the date-time-string up into the string-date and time-string part.
+  // and check whether these parts are RFC 3339 compliant.
+  const index = dateTimeString.indexOf('T');
+  const dateString = dateTimeString.substr(0, index);
+  const timeString = dateTimeString.substr(index + 1);
+  return (0, exports.validateDate)(dateString) && (0, exports.validateTime)(timeString);
+};
+
 export const GraphQLCustomDateTime = new GraphQLScalarType({
   name: 'CustomDateTime',
   description:
     'Custom DateTime scalar that wraps GraphQLDateTimeConfig and converts non-RFC 3339 strings to RFC 3339.',
   serialize: value => {
-    // helper to check if the date-time string is RFC 3339 compliant
-    const validateDateTime = (dateTimeString: string) => {
-      dateTimeString =
-        dateTimeString === null || dateTimeString === void 0
-          ? void 0
-          : dateTimeString.toUpperCase();
-      const RFC_3339_REGEX =
-        /^(\d{4}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9]|60))(\.\d{1,})?(([Z])|([+|-]([01][0-9]|2[0-3]):[0-5][0-9]))$/;
-      // Validate the structure of the date-string
-      if (!RFC_3339_REGEX.test(dateTimeString)) {
-        return false;
-      }
-      // Check if it is a correct date using the javascript Date parse() method.
-      const time = Date.parse(dateTimeString);
-      if (time !== time) {
-        // eslint-disable-line
-        return false;
-      }
-      // Split the date-time-string up into the string-date and time-string part.
-      // and check whether these parts are RFC 3339 compliant.
-      const index = dateTimeString.indexOf('T');
-      const dateString = dateTimeString.substr(0, index);
-      const timeString = dateTimeString.substr(index + 1);
-      return (0, exports.validateDate)(dateString) && (0, exports.validateTime)(timeString);
-    };
-
     if (typeof value === 'string' && !validateDateTime(value)) {
       // If the value doesn't match the RFC 3339, convert it to RFC 3339
       const formattedDate = moment(value).toISOString();

--- a/packages/loaders/json-schema/test/getComposerFromSchema.test.ts
+++ b/packages/loaders/json-schema/test/getComposerFromSchema.test.ts
@@ -22,7 +22,6 @@ import {
 } from 'graphql-compose';
 import {
   GraphQLBigInt,
-  GraphQLDateTime,
   GraphQLEmailAddress,
   GraphQLIPv4,
   GraphQLIPv6,
@@ -31,6 +30,7 @@ import {
   GraphQLURL,
 } from 'graphql-scalars';
 import { JSONSchemaObject } from 'json-machete';
+import { GraphQLCustomDateTime } from 'packages/loaders/json-schema/src/scalars';
 import { MeshPubSub } from '@graphql-mesh/types';
 import { DefaultLogger, PubSub } from '@graphql-mesh/utils';
 import { printSchemaWithDirectives } from '@graphql-tools/utils';
@@ -639,8 +639,8 @@ type ExampleAnyOf {
       format: 'date-time',
     };
     const result = await getComposerFromJSONSchema(inputSchema, logger);
-    expect(result.input.getType()).toBe(GraphQLDateTime);
-    expect((result.output as ScalarTypeComposer).getType()).toBe(GraphQLDateTime);
+    expect(result.input.getType()).toBe(GraphQLCustomDateTime);
+    expect((result.output as ScalarTypeComposer).getType()).toBe(GraphQLCustomDateTime);
   });
   it('should return Time scalar for time format', async () => {
     const inputSchema: JSONSchema = {

--- a/packages/loaders/openapi/package.json
+++ b/packages/loaders/openapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omnigraph/openapi",
-  "version": "0.95.5-TeslaOpenapiFixes",
+  "version": "0.95.5-TeslaOpenAPIFixes",
   "type": "module",
   "repository": {
     "type": "git",

--- a/packages/loaders/openapi/package.json
+++ b/packages/loaders/openapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omnigraph/openapi",
-  "version": "0.95.5-TeslaOpenAPIFixes-1",
+  "version": "0.95.5-TeslaOpenAPIFixes-2",
   "type": "module",
   "repository": {
     "type": "git",
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@graphql-mesh/string-interpolation": "^0.5.1",
-    "@omnigraph/json-schema": "0.95.5-TeslaOpenAPIFixes",
+    "@omnigraph/json-schema": "0.95.5-TeslaOpenAPIFixes-1",
     "change-case": "^4.1.2",
     "json-machete": "^0.95.4",
     "openapi-types": "^12.1.0"

--- a/packages/loaders/openapi/package.json
+++ b/packages/loaders/openapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omnigraph/openapi",
-  "version": "0.95.5",
+  "version": "0.95.5-TeslaOpenapiFixes",
   "type": "module",
   "repository": {
     "type": "git",
@@ -55,7 +55,8 @@
   },
   "publishConfig": {
     "access": "public",
-    "directory": "dist"
+    "directory": "dist",
+    "registry": "https://artifactory.teslamotors.com/artifactory/api/npm/digital-products-node-prod/"
   },
   "sideEffects": false,
   "typescript": {

--- a/packages/loaders/openapi/package.json
+++ b/packages/loaders/openapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omnigraph/openapi",
-  "version": "0.95.5-TeslaOpenAPIFixes",
+  "version": "0.95.5-TeslaOpenAPIFixes-1",
   "type": "module",
   "repository": {
     "type": "git",
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@graphql-mesh/string-interpolation": "^0.5.1",
-    "@omnigraph/json-schema": "^0.95.5",
+    "@omnigraph/json-schema": "0.95.5-TeslaOpenAPIFixes",
     "change-case": "^4.1.2",
     "json-machete": "^0.95.4",
     "openapi-types": "^12.1.0"

--- a/packages/loaders/openapi/package.json
+++ b/packages/loaders/openapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omnigraph/openapi",
-  "version": "0.95.5-TeslaOpenAPIFixes-2",
+  "version": "0.95.5-OpenAPIFixes",
   "type": "module",
   "repository": {
     "type": "git",
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@graphql-mesh/string-interpolation": "^0.5.1",
-    "@omnigraph/json-schema": "0.95.5-TeslaOpenAPIFixes-1",
+    "@omnigraph/json-schema": "0.95.5-OpenAPIFixes",
     "change-case": "^4.1.2",
     "json-machete": "^0.95.4",
     "openapi-types": "^12.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -554,7 +554,7 @@
 
 "@ardatan/grpc-reflection-js@^0.0.2":
   version "0.0.2"
-  resolved "https://artifactory.teslamotors.com/artifactory/api/npm/digital-products-node/@ardatan/grpc-reflection-js/-/grpc-reflection-js-0.0.2.tgz#e10f76e9b59c6ce1a8cd37bbfa3d47d596dea3b8"
+  resolved "https://registry.yarnpkg.com/@ardatan/grpc-reflection-js/-/grpc-reflection-js-0.0.2.tgz#e10f76e9b59c6ce1a8cd37bbfa3d47d596dea3b8"
   integrity sha512-O9UD3OLbtJ7DDZxiJs0ngmcJ9lWibx1RNL4WjiJPZC5s4RBkybwMgTgq8bBS7GF8iIkn+vkAGUt746GSW4d52A==
   dependencies:
     "@types/google-protobuf" "^3.7.2"
@@ -3193,7 +3193,7 @@
 
 "@graphql-mesh/grpc@0.95.6":
   version "0.95.6"
-  resolved "https://artifactory.teslamotors.com/artifactory/api/npm/digital-products-node/@graphql-mesh/grpc/-/grpc-0.95.6.tgz#bb71934b994a82372823f3ee36f0c6c91c16161e"
+  resolved "https://registry.yarnpkg.com/@graphql-mesh/grpc/-/grpc-0.95.6.tgz#bb71934b994a82372823f3ee36f0c6c91c16161e"
   integrity sha512-q0+DkLObr+dSbvZEXPIbUvKPGIEq1lAv1KuujGVi9C3PUoWEU4OApGe9MCgJVM9gdMadhf6x5E4PeiKvcCSZ1A==
   dependencies:
     "@ardatan/grpc-reflection-js" "^0.0.2"
@@ -3210,7 +3210,7 @@
 
 "@graphql-mesh/openapi@0.95.5":
   version "0.95.5"
-  resolved "https://artifactory.teslamotors.com/artifactory/api/npm/digital-products-node/@graphql-mesh/openapi/-/openapi-0.95.5.tgz#439c40288b07a956bcb329713e2f753658c3f993"
+  resolved "https://registry.yarnpkg.com/@graphql-mesh/openapi/-/openapi-0.95.5.tgz#439c40288b07a956bcb329713e2f753658c3f993"
   integrity sha512-gVMYpRHQGhIJsp7mHcu2fHT6h6l9P0lNdin9skJ480TnF3Tb+RQC3A0Lp/k/5i7hD6++MTdIZMXPV1osxCJcvQ==
   dependencies:
     "@graphql-mesh/string-interpolation" "0.5.1"
@@ -3218,7 +3218,7 @@
 
 "@graphql-mesh/string-interpolation@0.5.2":
   version "0.5.2"
-  resolved "https://artifactory.teslamotors.com/artifactory/api/npm/digital-products-node/@graphql-mesh/string-interpolation/-/string-interpolation-0.5.2.tgz#af89cd63b27e7c2c85e994872be2ed18eaad07e1"
+  resolved "https://registry.yarnpkg.com/@graphql-mesh/string-interpolation/-/string-interpolation-0.5.2.tgz#af89cd63b27e7c2c85e994872be2ed18eaad07e1"
   integrity sha512-TkSAJ9pj1zesQyDlHrEUevVGOc1s/z9IQC0AONcpMHAunb8uYGO4Yryl8JIRIvDl5DlexHt3z8kLDNCInRGWNQ==
   dependencies:
     dayjs "1.11.10"
@@ -4817,7 +4817,7 @@
 
 "@omnigraph/json-schema@0.95.5":
   version "0.95.5"
-  resolved "https://artifactory.teslamotors.com/artifactory/api/npm/digital-products-node/@omnigraph/json-schema/-/@omnigraph/json-schema-0.95.5.tgz#602b36f81ad358b9b04af57df1bdb9b850b93f62"
+  resolved "https://registry.yarnpkg.com/@omnigraph/json-schema/-/@omnigraph/json-schema-0.95.5.tgz#602b36f81ad358b9b04af57df1bdb9b850b93f62"
   integrity sha512-qkeuGY0HZgafaJwHkEl83A193J5f1ThVR4Otm5KlJDMkkPTta2kSXg1TY2vpfD6hB3893cNKdgR2dgrcxBlrdw==
   dependencies:
     "@graphql-mesh/string-interpolation" "0.5.1"
@@ -4836,7 +4836,7 @@
 
 "@omnigraph/json-schema@^0.95.5":
   version "0.95.7"
-  resolved "https://artifactory.teslamotors.com/artifactory/api/npm/digital-products-node/@omnigraph/json-schema/-/json-schema-0.95.7.tgz#86541ae514629750269da8c7ff9327285c19698b"
+  resolved "https://registry.yarnpkg.com/@omnigraph/json-schema/-/json-schema-0.95.7.tgz#86541ae514629750269da8c7ff9327285c19698b"
   integrity sha512-TBmXPKKZ7PFfgQTVMDpymlDiwdEY/guVlKt9CccBIqgvhHFgwUpdyYGpMHl4cXuO1AC0M9UUqrhtBQtKuiQvQw==
   dependencies:
     "@graphql-mesh/string-interpolation" "0.5.2"
@@ -4855,7 +4855,7 @@
 
 "@omnigraph/openapi@0.95.5":
   version "0.95.5"
-  resolved "https://artifactory.teslamotors.com/artifactory/api/npm/digital-products-node/@omnigraph/openapi/-/openapi-0.95.5.tgz#adec46c880989ded0f18aca2008ee68232acab47"
+  resolved "https://registry.yarnpkg.com/@omnigraph/openapi/-/openapi-0.95.5.tgz#adec46c880989ded0f18aca2008ee68232acab47"
   integrity sha512-o37kfc0pYM+AfypzWd3mhiPU636TObJ81kbdabJ1yRWMSOj143PZmnZ3gXIzN+P9AixcL5ee2MlYjzL+c9oYRA==
   dependencies:
     "@graphql-mesh/string-interpolation" "^0.5.1"
@@ -10017,7 +10017,7 @@ date-format@^4.0.14:
 
 dayjs@1.11.10:
   version "1.11.10"
-  resolved "https://artifactory.teslamotors.com/artifactory/api/npm/digital-products-node/dayjs/-/dayjs-1.11.10.tgz#68acea85317a6e164457d6d6947564029a6a16a0"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.10.tgz#68acea85317a6e164457d6d6947564029a6a16a0"
   integrity sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ==
 
 dayjs@1.11.9, dayjs@^1.11.7:
@@ -14913,7 +14913,7 @@ json-buffer@3.0.1:
 
 json-machete@0.95.6:
   version "0.95.6"
-  resolved "https://artifactory.teslamotors.com/artifactory/api/npm/digital-products-node/json-machete/-/json-machete-0.95.6.tgz#3678963aa821b013c72d04afd911f49b2061560c"
+  resolved "https://registry.yarnpkg.com/json-machete/-/json-machete-0.95.6.tgz#3678963aa821b013c72d04afd911f49b2061560c"
   integrity sha512-Iu+UPfVEz8yI1Yw5Jp3iIwWIiQPketsAsCDbeLCD5LYVlIy7Nwn/ME6NV5JqcRm/zzY10rYMj00bEBUK2cDwdw==
   dependencies:
     "@json-schema-tools/meta-schema" "1.7.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -552,6 +552,16 @@
     mkdirp "1.0.3"
     yargs "15.3.1"
 
+"@ardatan/grpc-reflection-js@^0.0.2":
+  version "0.0.2"
+  resolved "https://artifactory.teslamotors.com/artifactory/api/npm/digital-products-node/@ardatan/grpc-reflection-js/-/grpc-reflection-js-0.0.2.tgz#e10f76e9b59c6ce1a8cd37bbfa3d47d596dea3b8"
+  integrity sha512-O9UD3OLbtJ7DDZxiJs0ngmcJ9lWibx1RNL4WjiJPZC5s4RBkybwMgTgq8bBS7GF8iIkn+vkAGUt746GSW4d52A==
+  dependencies:
+    "@types/google-protobuf" "^3.7.2"
+    "@types/lodash.set" "^4.3.6"
+    google-protobuf "^3.12.2"
+    lodash.set "^4.3.2"
+
 "@ardatan/raml-1-parser@1.1.69":
   version "1.1.69"
   resolved "https://registry.yarnpkg.com/@ardatan/raml-1-parser/-/raml-1-parser-1.1.69.tgz#c6fa1c8430f5f93abe47385e33c29312f793ecbf"
@@ -3181,6 +3191,40 @@
     object-inspect "1.12.3"
     tslib "2.6.0"
 
+"@graphql-mesh/grpc@0.95.6":
+  version "0.95.6"
+  resolved "https://artifactory.teslamotors.com/artifactory/api/npm/digital-products-node/@graphql-mesh/grpc/-/grpc-0.95.6.tgz#bb71934b994a82372823f3ee36f0c6c91c16161e"
+  integrity sha512-q0+DkLObr+dSbvZEXPIbUvKPGIEq1lAv1KuujGVi9C3PUoWEU4OApGe9MCgJVM9gdMadhf6x5E4PeiKvcCSZ1A==
+  dependencies:
+    "@ardatan/grpc-reflection-js" "^0.0.2"
+    "@graphql-mesh/string-interpolation" "^0.5.1"
+    "@grpc/grpc-js" "^1.1.7"
+    "@grpc/proto-loader" "^0.7.8"
+    globby "^11.1.0"
+    graphql-compose "^9.0.10"
+    graphql-scalars "^1.22.2"
+    lodash.get "^4.4.2"
+    lodash.has "^4.5.2"
+    long "4.0.0"
+    protobufjs "^7.2.5"
+
+"@graphql-mesh/openapi@0.95.5":
+  version "0.95.5"
+  resolved "https://artifactory.teslamotors.com/artifactory/api/npm/digital-products-node/@graphql-mesh/openapi/-/openapi-0.95.5.tgz#439c40288b07a956bcb329713e2f753658c3f993"
+  integrity sha512-gVMYpRHQGhIJsp7mHcu2fHT6h6l9P0lNdin9skJ480TnF3Tb+RQC3A0Lp/k/5i7hD6++MTdIZMXPV1osxCJcvQ==
+  dependencies:
+    "@graphql-mesh/string-interpolation" "0.5.1"
+    "@omnigraph/openapi" "0.95.5"
+
+"@graphql-mesh/string-interpolation@0.5.2":
+  version "0.5.2"
+  resolved "https://artifactory.teslamotors.com/artifactory/api/npm/digital-products-node/@graphql-mesh/string-interpolation/-/string-interpolation-0.5.2.tgz#af89cd63b27e7c2c85e994872be2ed18eaad07e1"
+  integrity sha512-TkSAJ9pj1zesQyDlHrEUevVGOc1s/z9IQC0AONcpMHAunb8uYGO4Yryl8JIRIvDl5DlexHt3z8kLDNCInRGWNQ==
+  dependencies:
+    dayjs "1.11.10"
+    json-pointer "0.6.2"
+    lodash.get "4.4.2"
+
 "@graphql-tools/batch-delegate@^9.0.0":
   version "9.0.0"
   resolved "https://registry.yarnpkg.com/@graphql-tools/batch-delegate/-/batch-delegate-9.0.0.tgz#dd9e87466f450bae61a20525a2a8d8b0d257df37"
@@ -4770,6 +4814,55 @@
     log-chopper "^1.0.2"
     semver "^7.5.1"
     tar-fs "^2.1.1"
+
+"@omnigraph/json-schema@0.95.5":
+  version "0.95.5"
+  resolved "https://artifactory.teslamotors.com/artifactory/api/npm/digital-products-node/@omnigraph/json-schema/-/@omnigraph/json-schema-0.95.5.tgz#602b36f81ad358b9b04af57df1bdb9b850b93f62"
+  integrity sha512-qkeuGY0HZgafaJwHkEl83A193J5f1ThVR4Otm5KlJDMkkPTta2kSXg1TY2vpfD6hB3893cNKdgR2dgrcxBlrdw==
+  dependencies:
+    "@graphql-mesh/string-interpolation" "0.5.1"
+    "@json-schema-tools/meta-schema" "1.7.0"
+    "@whatwg-node/fetch" "^0.9.0"
+    ajv "8.12.0"
+    ajv-formats "2.1.1"
+    dset "3.1.2"
+    graphql-compose "9.0.10"
+    graphql-scalars "^1.22.2"
+    json-machete "0.95.4"
+    pascal-case "3.1.2"
+    qs "6.11.2"
+    to-json-schema "0.2.5"
+    url-join "4.0.1"
+
+"@omnigraph/json-schema@^0.95.5":
+  version "0.95.7"
+  resolved "https://artifactory.teslamotors.com/artifactory/api/npm/digital-products-node/@omnigraph/json-schema/-/json-schema-0.95.7.tgz#86541ae514629750269da8c7ff9327285c19698b"
+  integrity sha512-TBmXPKKZ7PFfgQTVMDpymlDiwdEY/guVlKt9CccBIqgvhHFgwUpdyYGpMHl4cXuO1AC0M9UUqrhtBQtKuiQvQw==
+  dependencies:
+    "@graphql-mesh/string-interpolation" "0.5.2"
+    "@json-schema-tools/meta-schema" "1.7.0"
+    "@whatwg-node/fetch" "^0.9.0"
+    ajv "8.12.0"
+    ajv-formats "2.1.1"
+    dset "3.1.2"
+    graphql-compose "9.0.10"
+    graphql-scalars "^1.22.2"
+    json-machete "0.95.6"
+    pascal-case "3.1.2"
+    qs "6.11.2"
+    to-json-schema "0.2.5"
+    url-join "4.0.1"
+
+"@omnigraph/openapi@0.95.5":
+  version "0.95.5"
+  resolved "https://artifactory.teslamotors.com/artifactory/api/npm/digital-products-node/@omnigraph/openapi/-/openapi-0.95.5.tgz#adec46c880989ded0f18aca2008ee68232acab47"
+  integrity sha512-o37kfc0pYM+AfypzWd3mhiPU636TObJ81kbdabJ1yRWMSOj143PZmnZ3gXIzN+P9AixcL5ee2MlYjzL+c9oYRA==
+  dependencies:
+    "@graphql-mesh/string-interpolation" "^0.5.1"
+    "@omnigraph/json-schema" "^0.95.5"
+    change-case "^4.1.2"
+    json-machete "^0.95.4"
+    openapi-types "^12.1.0"
 
 "@opentelemetry/api@^1.0.1":
   version "1.6.0"
@@ -9922,6 +10015,11 @@ date-format@^4.0.14:
   resolved "https://registry.yarnpkg.com/date-format/-/date-format-4.0.14.tgz#7a8e584434fb169a521c8b7aa481f355810d9400"
   integrity sha512-39BOQLs9ZjKh0/patS9nrT8wc3ioX3/eA/zgbKNopnF2wCqJEoxywwwElATYvRsXdnOxA/OQeQoFZ3rFjVajhg==
 
+dayjs@1.11.10:
+  version "1.11.10"
+  resolved "https://artifactory.teslamotors.com/artifactory/api/npm/digital-products-node/dayjs/-/dayjs-1.11.10.tgz#68acea85317a6e164457d6d6947564029a6a16a0"
+  integrity sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ==
+
 dayjs@1.11.9, dayjs@^1.11.7:
   version "1.11.9"
   resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.9.tgz#9ca491933fadd0a60a2c19f6c237c03517d71d1a"
@@ -14812,6 +14910,17 @@ json-buffer@3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/json-buffer/-/json-buffer-3.0.1.tgz#9338802a30d3b6605fbe0613e094008ca8c05a13"
   integrity sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==
+
+json-machete@0.95.6:
+  version "0.95.6"
+  resolved "https://artifactory.teslamotors.com/artifactory/api/npm/digital-products-node/json-machete/-/json-machete-0.95.6.tgz#3678963aa821b013c72d04afd911f49b2061560c"
+  integrity sha512-Iu+UPfVEz8yI1Yw5Jp3iIwWIiQPketsAsCDbeLCD5LYVlIy7Nwn/ME6NV5JqcRm/zzY10rYMj00bEBUK2cDwdw==
+  dependencies:
+    "@json-schema-tools/meta-schema" "1.7.0"
+    "@whatwg-node/fetch" "^0.9.0"
+    json-pointer "0.6.2"
+    to-json-schema "0.2.5"
+    url-join "4.0.1"
 
 json-parse-better-errors@^1.0.1:
   version "1.0.2"


### PR DESCRIPTION
There are date-time strings which aren't RFC 3339 compliant which is a requirement for DateTimeScalar in the graphql-scalars. Instead of modifying the date-time in the schema, we should create a translation layer which convert the date-time Strings to be RFC 3339 compliant.